### PR TITLE
feat(lead): implementando novos opções estáticas para select de status - LPV-27

### DIFF
--- a/components/molecules/Selects/ZSelectStatusLead.vue
+++ b/components/molecules/Selects/ZSelectStatusLead.vue
@@ -62,6 +62,9 @@ export default {
           { text: "qualified", value: "qualified" },
           { text: "bad_email", value: "bad_email" },
           { text: "spam", value: "spam" },
+          { text: "test", value: "test" },
+          { text: "trial_period", value: "trial_period" },
+          { text: "active_customer", value: "active_customer" },
         ];
 
         this.loading = false;

--- a/components/organisms/Datatables/Leads/ZDatatablesLeads.vue
+++ b/components/organisms/Datatables/Leads/ZDatatablesLeads.vue
@@ -230,6 +230,7 @@ async function alterStatusLead() {
   await $customFetch(`/leads/${leadId.value}`, "PUT", {
     body: JSON.stringify({
       status: statusLead.value.value,
+      tenantId: tenantIdForm.value,
       id: leadId.value,
     }),
   })


### PR DESCRIPTION
* Adicionado novas opções estáticas de status para leads.
* Também foi ajustado um erro ao editar o status de um lead, campo obrigatório tenantId faltando